### PR TITLE
Update vector space utility functions for all spaces

### DIFF
--- a/gymnasium/spaces/sequence.py
+++ b/gymnasium/spaces/sequence.py
@@ -46,7 +46,7 @@ class Sequence(Space[Union[typing.Tuple[Any, ...], Any]]):
         self.feature_space = space
         self.stack = stack
         if self.stack:
-            self.batched_feature_space: Space = gym.vector.utils.batch_space(
+            self.stacked_feature_space: Space = gym.vector.utils.batch_space(
                 self.feature_space, 1
             )
 
@@ -141,7 +141,7 @@ class Sequence(Space[Union[typing.Tuple[Any, ...], Any]]):
         if self.stack:
             return all(
                 item in self.feature_space
-                for item in gym.vector.utils.iterate(self.batched_feature_space, x)
+                for item in gym.vector.utils.iterate(self.stacked_feature_space, x)
             )
         else:
             return isinstance(x, tuple) and all(
@@ -157,14 +157,14 @@ class Sequence(Space[Union[typing.Tuple[Any, ...], Any]]):
     ) -> list[list[Any]]:
         """Convert a batch of samples from this space to a JSONable data type."""
         if self.stack:
-            return self.batched_feature_space.to_jsonable(sample_n)
+            return self.stacked_feature_space.to_jsonable(sample_n)
         else:
             return [self.feature_space.to_jsonable(sample) for sample in sample_n]
 
     def from_jsonable(self, sample_n: list[list[Any]]) -> list[tuple[Any, ...] | Any]:
         """Convert a JSONable data type to a batch of samples from this space."""
         if self.stack:
-            return self.batched_feature_space.from_jsonable(sample_n)
+            return self.stacked_feature_space.from_jsonable(sample_n)
         else:
             return [
                 tuple(self.feature_space.from_jsonable(sample)) for sample in sample_n

--- a/gymnasium/spaces/utils.py
+++ b/gymnasium/spaces/utils.py
@@ -243,7 +243,7 @@ def _flatten_sequence(
     space: Sequence, x: tuple[Any, ...] | Any
 ) -> tuple[Any, ...] | Any:
     if space.stack:
-        samples_iters = gym.vector.utils.iterate(space.batched_feature_space, x)
+        samples_iters = gym.vector.utils.iterate(space.stacked_feature_space, x)
         flattened_samples = [
             flatten(space.feature_space, sample) for sample in samples_iters
         ]

--- a/tests/experimental/vector/utils/utils.py
+++ b/tests/experimental/vector/utils/utils.py
@@ -1,0 +1,7 @@
+"""Utility functions for testing the vector utility functions."""
+import numpy as np
+
+
+def is_rng_equal(rng_1: np.random.Generator, rng_2: np.random.Generator):
+    """Asserts that two random number generates are equivalent."""
+    return rng_1.bit_generator.state == rng_2.bit_generator.state

--- a/tests/spaces/test_space.py
+++ b/tests/spaces/test_space.py
@@ -2,22 +2,19 @@ from functools import partial
 
 import pytest
 
-from gymnasium import Space
 from gymnasium.spaces import utils
-
-
-TESTING_SPACE = Space()
+from tests.spaces.utils import TESTING_CUSTOM_SPACE
 
 
 @pytest.mark.parametrize(
     "func",
     [
-        TESTING_SPACE.sample,
-        partial(TESTING_SPACE.contains, None),
-        partial(utils.flatdim, TESTING_SPACE),
-        partial(utils.flatten, TESTING_SPACE, None),
-        partial(utils.flatten_space, TESTING_SPACE),
-        partial(utils.unflatten, TESTING_SPACE, None),
+        TESTING_CUSTOM_SPACE.sample,
+        partial(TESTING_CUSTOM_SPACE.contains, None),
+        partial(utils.flatdim, TESTING_CUSTOM_SPACE),
+        partial(utils.flatten, TESTING_CUSTOM_SPACE, None),
+        partial(utils.flatten_space, TESTING_CUSTOM_SPACE),
+        partial(utils.unflatten, TESTING_CUSTOM_SPACE, None),
     ],
 )
 def test_not_implemented_errors(func):

--- a/tests/spaces/utils.py
+++ b/tests/spaces/utils.py
@@ -112,9 +112,10 @@ TESTING_COMPOSITE_SPACES_IDS = [f"{space}" for space in TESTING_COMPOSITE_SPACES
 TESTING_SPACES: List[Space] = TESTING_FUNDAMENTAL_SPACES + TESTING_COMPOSITE_SPACES
 TESTING_SPACES_IDS = TESTING_FUNDAMENTAL_SPACES_IDS + TESTING_COMPOSITE_SPACES_IDS
 
-CUSTOM_SPACES = [
-    Space(),
-    Tuple([Space(), Space(), Space()]),
-    Dict(a=Space(), b=Space()),
-]
-CUSTOM_SPACES_IDS = [f"{space}" for space in CUSTOM_SPACES]
+
+class CustomSpace(Space):
+    def __eq__(self, o: object) -> bool:
+        return isinstance(o, CustomSpace)
+
+
+TESTING_CUSTOM_SPACE = CustomSpace()


### PR DESCRIPTION
Recreated from original PR: https://github.com/Farama-Foundation/Gymnasium/pull/223

I am improving some of the wrappers and I found that we can use several of the built-in vector functions for generating empty arrays, stacking observations, etc

In this PR, I have copied the original space utility functions from vector which were in two files, `spaces` and `numpy_utils` into a single file, `space_utils`, the functions are `batch_space`, `concatenate`, `iterate` and `create_empty_array`

I have not changed the implementation of the functions other than adding new functions f...